### PR TITLE
fix capitalization

### DIFF
--- a/aby3/Circuit/Garble.h
+++ b/aby3/Circuit/Garble.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <cryptoTools/Circuit/betacircuit.h>
+#include <cryptoTools/Circuit/BetaCircuit.h>
 #include <vector>
 #include <array>
 #include <functional>


### PR DESCRIPTION
macs usually ignore caps but ubuntu does not