### PR TITLE
Updated download link for eigen

### DIFF
--- a/thirdparty/linux/eigen.get
+++ b/thirdparty/linux/eigen.get
@@ -3,9 +3,9 @@
 set -e
 
 if [ ! -d eigen ]; then
-    wget -c 'http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2' -O ./eigen.tar.bz2
+    wget -c 'https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.tar.bz2' -O ./eigen.tar.bz2
     tar xfj eigen.tar.bz2
-    mv eigen-eigen-5a0156e40feb eigen
+    mv eigen-3.3.4 eigen
     rm  eigen.tar.bz2
 fi
 


### PR DESCRIPTION
## What does this PR do?
Updates the download link for Eigen.

## Why is this PR necessary?
Eigen moved their hosting from bitbucket to gitlab thus breaking the download link in eigen.get
