### PR TITLE
fix the or gate logic

### DIFF
--- a/aby3/sh3/Sh3BinaryEvaluator.cpp
+++ b/aby3/sh3/Sh3BinaryEvaluator.cpp
@@ -914,96 +914,62 @@ namespace aby3
 					z = getShares();
 					for (i32 k = 0; k < simdWidth128; k += 8)
 					{
-						// t0 = mem00
-						t0[0] = s0_in0[k + 0] ^ AllOneBlock;
-						t0[1] = s0_in0[k + 1] ^ AllOneBlock;
-						t0[2] = s0_in0[k + 2] ^ AllOneBlock;
-						t0[3] = s0_in0[k + 3] ^ AllOneBlock;
-						t0[4] = s0_in0[k + 4] ^ AllOneBlock;
-						t0[5] = s0_in0[k + 5] ^ AllOneBlock;
-						t0[6] = s0_in0[k + 6] ^ AllOneBlock;
-						t0[7] = s0_in0[k + 7] ^ AllOneBlock;
+						// the following OR gate logic is: z = (x & y) ^ (x ^ y).
+						// 1. first comput the and gate.
+						t0[0] = s0_in0[k + 0] & s0_in1[k + 0];
+						t0[1] = s0_in0[k + 1] & s0_in1[k + 1];
+						t0[2] = s0_in0[k + 2] & s0_in1[k + 2];
+						t0[3] = s0_in0[k + 3] & s0_in1[k + 3];
+						t0[4] = s0_in0[k + 4] & s0_in1[k + 4];
+						t0[5] = s0_in0[k + 5] & s0_in1[k + 5];
+						t0[6] = s0_in0[k + 6] & s0_in1[k + 6];
+						t0[7] = s0_in0[k + 7] & s0_in1[k + 7];
 
-						// t1 = mem01
-						t1[0] = s0_in1[k + 0] ^ AllOneBlock;
-						t1[1] = s0_in1[k + 1] ^ AllOneBlock;
-						t1[2] = s0_in1[k + 2] ^ AllOneBlock;
-						t1[3] = s0_in1[k + 3] ^ AllOneBlock;
-						t1[4] = s0_in1[k + 4] ^ AllOneBlock;
-						t1[5] = s0_in1[k + 5] ^ AllOneBlock;
-						t1[6] = s0_in1[k + 6] ^ AllOneBlock;
-						t1[7] = s0_in1[k + 7] ^ AllOneBlock;
+						t1[0] = s0_in0[k + 0] & s1_in1[k + 0];
+						t1[1] = s0_in0[k + 1] & s1_in1[k + 1];
+						t1[2] = s0_in0[k + 2] & s1_in1[k + 2];
+						t1[3] = s0_in0[k + 3] & s1_in1[k + 3];
+						t1[4] = s0_in0[k + 4] & s1_in1[k + 4];
+						t1[5] = s0_in0[k + 5] & s1_in1[k + 5];
+						t1[6] = s0_in0[k + 6] & s1_in1[k + 6];
+						t1[7] = s0_in0[k + 7] & s1_in1[k + 7];
 
-						// t2 = mem10
-						t2[0] = s1_in0[k + 0] ^ AllOneBlock;
-						t2[1] = s1_in0[k + 1] ^ AllOneBlock;
-						t2[2] = s1_in0[k + 2] ^ AllOneBlock;
-						t2[3] = s1_in0[k + 3] ^ AllOneBlock;
-						t2[4] = s1_in0[k + 4] ^ AllOneBlock;
-						t2[5] = s1_in0[k + 5] ^ AllOneBlock;
-						t2[6] = s1_in0[k + 6] ^ AllOneBlock;
-						t2[7] = s1_in0[k + 7] ^ AllOneBlock;
+						t0[0] = t0[0] ^ t1[0];
+						t0[1] = t0[1] ^ t1[1];
+						t0[2] = t0[2] ^ t1[2];
+						t0[3] = t0[3] ^ t1[3];
+						t0[4] = t0[4] ^ t1[4];
+						t0[5] = t0[5] ^ t1[5];
+						t0[6] = t0[6] ^ t1[6];
+						t0[7] = t0[7] ^ t1[7];
 
-						// t3 = mem11 & mem00
-						s0_Out[k + 0] = s1_in1[k + 0] & t0[0];
-						s0_Out[k + 1] = s1_in1[k + 1] & t0[1];
-						s0_Out[k + 2] = s1_in1[k + 2] & t0[2];
-						s0_Out[k + 3] = s1_in1[k + 3] & t0[3];
-						s0_Out[k + 4] = s1_in1[k + 4] & t0[4];
-						s0_Out[k + 5] = s1_in1[k + 5] & t0[5];
-						s0_Out[k + 6] = s1_in1[k + 6] & t0[6];
-						s0_Out[k + 7] = s1_in1[k + 7] & t0[7];
+						t1[0] = s1_in0[k + 0] & s0_in1[k + 0];
+						t1[1] = s1_in0[k + 1] & s0_in1[k + 1];
+						t1[2] = s1_in0[k + 2] & s0_in1[k + 2];
+						t1[3] = s1_in0[k + 3] & s0_in1[k + 3];
+						t1[4] = s1_in0[k + 4] & s0_in1[k + 4];
+						t1[5] = s1_in0[k + 5] & s0_in1[k + 5];
+						t1[6] = s1_in0[k + 6] & s0_in1[k + 6];
+						t1[7] = s1_in0[k + 7] & s0_in1[k + 7];
 
-						// t2 = mem10 & mem01
-						t2[0] = t2[0] & t1[0];
-						t2[1] = t2[1] & t1[1];
-						t2[2] = t2[2] & t1[2];
-						t2[3] = t2[3] & t1[3];
-						t2[4] = t2[4] & t1[4];
-						t2[5] = t2[5] & t1[5];
-						t2[6] = t2[6] & t1[6];
-						t2[7] = t2[7] & t1[7];
+						t0[0] = t0[0] ^ t1[0];
+						t0[1] = t0[1] ^ t1[1];
+						t0[2] = t0[2] ^ t1[2];
+						t0[3] = t0[3] ^ t1[3];
+						t0[4] = t0[4] ^ t1[4];
+						t0[5] = t0[5] ^ t1[5];
+						t0[6] = t0[6] ^ t1[6];
+						t0[7] = t0[7] ^ t1[7];
 
-						// out = mem11 & mem00 ^ mem10 & mem01
-						s0_Out[k + 0] = s0_Out[k + 0] ^ t2[0];
-						s0_Out[k + 1] = s0_Out[k + 1] ^ t2[1];
-						s0_Out[k + 2] = s0_Out[k + 2] ^ t2[2];
-						s0_Out[k + 3] = s0_Out[k + 3] ^ t2[3];
-						s0_Out[k + 4] = s0_Out[k + 4] ^ t2[4];
-						s0_Out[k + 5] = s0_Out[k + 5] ^ t2[5];
-						s0_Out[k + 6] = s0_Out[k + 6] ^ t2[6];
-						s0_Out[k + 7] = s0_Out[k + 7] ^ t2[7];
-
-						// t1 = mem00 & mem01
-						t1[0] = t0[0] & t1[0];
-						t1[1] = t0[1] & t1[1];
-						t1[2] = t0[2] & t1[2];
-						t1[3] = t0[3] & t1[3];
-						t1[4] = t0[4] & t1[4];
-						t1[5] = t0[5] & t1[5];
-						t1[6] = t0[6] & t1[6];
-						t1[7] = t0[7] & t1[7];
-
-						// out = mem11 & mem00 ^ mem10 & mem01 ^ mem00 & mem01
-						s0_Out[k + 0] = s0_Out[k + 0] ^ t1[0];
-						s0_Out[k + 1] = s0_Out[k + 1] ^ t1[1];
-						s0_Out[k + 2] = s0_Out[k + 2] ^ t1[2];
-						s0_Out[k + 3] = s0_Out[k + 3] ^ t1[3];
-						s0_Out[k + 4] = s0_Out[k + 4] ^ t1[4];
-						s0_Out[k + 5] = s0_Out[k + 5] ^ t1[5];
-						s0_Out[k + 6] = s0_Out[k + 6] ^ t1[6];
-						s0_Out[k + 7] = s0_Out[k + 7] ^ t1[7];
-
-						// out = mem11 & mem00 ^ mem10 & mem01 ^ mem00 & mem01 ^ z0 ^ z1
-						s0_Out[k + 0] = s0_Out[k + 0] ^ z[k + 0];
-						s0_Out[k + 1] = s0_Out[k + 1] ^ z[k + 1];
-						s0_Out[k + 2] = s0_Out[k + 2] ^ z[k + 2];
-						s0_Out[k + 3] = s0_Out[k + 3] ^ z[k + 3];
-						s0_Out[k + 4] = s0_Out[k + 4] ^ z[k + 4];
-						s0_Out[k + 5] = s0_Out[k + 5] ^ z[k + 5];
-						s0_Out[k + 6] = s0_Out[k + 6] ^ z[k + 6];
-						s0_Out[k + 7] = s0_Out[k + 7] ^ z[k + 7];
-
+						// 2. then comput the xor gate.
+						s0_Out[k + 0] = t0[0] ^ s0_in0[k + 0] ^ s0_in1[k + 0] ^ z[k + 0];
+						s0_Out[k + 1] = t0[1] ^ s0_in0[k + 1] ^ s0_in1[k + 1] ^ z[k + 1];
+						s0_Out[k + 2] = t0[2] ^ s0_in0[k + 2] ^ s0_in1[k + 2] ^ z[k + 2];
+						s0_Out[k + 3] = t0[3] ^ s0_in0[k + 3] ^ s0_in1[k + 3] ^ z[k + 3];
+						s0_Out[k + 4] = t0[4] ^ s0_in0[k + 4] ^ s0_in1[k + 4] ^ z[k + 4];
+						s0_Out[k + 5] = t0[5] ^ s0_in0[k + 5] ^ s0_in1[k + 5] ^ z[k + 5];
+						s0_Out[k + 6] = t0[6] ^ s0_in0[k + 6] ^ s0_in1[k + 6] ^ z[k + 6];
+						s0_Out[k + 7] = t0[7] ^ s0_in0[k + 7] ^ s0_in1[k + 7] ^ z[k + 7];
 					}
 
 #ifndef NDEBUG


### PR DESCRIPTION
Hi Peter,

I found that the ``GateType::Or`` logic in the current ``Sh3BinaryEvaluator.cpp``  is actually the logic of ``na_And`` gate, which causes the wrong result of evaluating Or gate.

Also, the ``G`` gate in the int substraction circuit in the deps should be ``na_And`` instead of ``Or``, as the boorow bit should 1 only when a = 0 and b = 1. (https://github.com/ladnir/cryptoTools/blob/5f90354b499adddbcf6861a3b4463e0724e5f719/cryptoTools/Circuit/BetaLibrary.cpp#L1122)

In this PR, i fixed the Or gate logic, for z = a | b, it follws that z =  (a & b) ^ (a ^ b).

I locally checked the correctness and passed all the test cases. 