### PR TITLE
build.py: replace `os.system` with `subprocess.run`

### DIFF
--- a/build.py
+++ b/build.py
@@ -2,6 +2,7 @@ import os
 import platform
 import sys
 import multiprocessing
+import subprocess
 
 if __name__ == "__main__":
     import thirdparty.getEigen as getEigen
@@ -78,9 +79,9 @@ def Build(mainArgs, cmakeArgs,install, prefix, par):
 
 
 
-    mkDirCmd = "mkdir -p {0}".format(buildDir); 
-    CMakeCmd = "cmake -S . -B {0} {1}".format(buildDir, argStr)
-    BuildCmd = "cmake --build {0} {1} {2} ".format(buildDir, config, parallel)
+    mkDirCmd = "mkdir -p {0}".format(buildDir).split()
+    CMakeCmd = "cmake -S . -B {0} {1}".format(buildDir, argStr).split()
+    BuildCmd = "cmake --build {0} {1} {2} ".format(buildDir, config, parallel).split()
 
 
     #InstallCmd = ""
@@ -104,13 +105,13 @@ def Build(mainArgs, cmakeArgs,install, prefix, par):
     #    print(InstallCmd)
     print("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n")
 
-    os.system(mkDirCmd)
-    os.system(CMakeCmd)
-    os.system(BuildCmd)
+    subprocess.run(mkDirCmd, check=True)
+    subprocess.run(CMakeCmd, check=True)
+    subprocess.run(BuildCmd, check=True)
     #if len(sudo) > 0:
     #    print("installing libraries: {0}".format(InstallCmd))
     #
-    #os.system(InstallCmd)
+    #subprocess.run(InstallCmd, check=True)
 
 
 def getInstallArgs(args):

--- a/thirdparty/getEigen.py
+++ b/thirdparty/getEigen.py
@@ -77,16 +77,16 @@ def getEigen(install, prefix, par):
         if install and len(prefix) == 0:
             prefix = "/usr/local"
 
-        mkdirCmd = sudo + "mkdir -p " + prefix + "/include/Eigen/"
-        InstallCmd = sudo + "cp  -rf ./Eigen " + prefix + "/include" 
+        mkdirCmd = (sudo + "mkdir -p " + prefix + "/include/Eigen/").split()
+        InstallCmd = (sudo + "cp  -rf ./Eigen " + prefix + "/include").split()
 
         print("\n=========== getEigen.py =============")
         print(mkdirCmd)
         print(InstallCmd)
         print("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n")
 
-        os.system(mkdirCmd)
-        os.system(InstallCmd)
+        subprocess.run(mkdirCmd, check=True)
+        subprocess.run(InstallCmd, check=True)
 
         #buildDir = "out/unix"
         

--- a/thirdparty/getFunction2.py
+++ b/thirdparty/getFunction2.py
@@ -19,9 +19,9 @@ def getFunction2(install, prefix, par):
     url = "https://github.com/Naios/function2.git"
 
     if os.path.exists(folder) == False:
-        os.system("git clone --depth 1 " + url)
+        subprocess.run(("git clone --depth 1 " + url).split(), check=True)
     os.chdir(folder)
-    os.system("git checkout 3a0746bf5f601dfed05330aefcb6854354fce07d")
+    subprocess.run("git checkout 3a0746bf5f601dfed05330aefcb6854354fce07d".split(), check=True)
 
     sudo = ""
     if(osStr == "Windows"):
@@ -59,16 +59,16 @@ def getFunction2(install, prefix, par):
         if install and len(prefix) == 0:
             prefix = "/usr/local"
 
-        mkdirCmd = sudo + "mkdir -p " + prefix + "/include/function2/"
-        InstallCmd = sudo + "cp  -rf ./include/function2 " + prefix + "/include" 
+        mkdirCmd = (sudo + "mkdir -p " + prefix + "/include/function2/").split()
+        InstallCmd = (sudo + "cp  -rf ./include/function2 " + prefix + "/include").split()
 
         print("\n=========== getFunction2.py =============")
         print(mkdirCmd)
         print(InstallCmd)
         print("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n")
 
-        os.system(mkdirCmd)
-        os.system(InstallCmd)
+        subprocess.run(mkdirCmd, check=True)
+        subprocess.run(InstallCmd, check=True)
 
         #buildDir = "out/unix"
         

--- a/thirdparty/getJson.py
+++ b/thirdparty/getJson.py
@@ -19,9 +19,9 @@ def getJson(install, prefix, par):
     url = "https://github.com/nlohmann/json.git  "
 
     if os.path.exists(folder) == False:
-        os.system("git clone --depth 1 " + url)
+        subprocess.run(("git clone --depth 1 " + url).split(), check=True)
     os.chdir(folder)
-    #os.system("git checkout 3a0746bf5f601dfed05330aefcb6854354fce07d")
+    #subprocess.run("git checkout 3a0746bf5f601dfed05330aefcb6854354fce07d".split(), check=True)
 
     sudo = ""
     if(osStr == "Windows"):
@@ -59,16 +59,16 @@ def getJson(install, prefix, par):
         if install and len(prefix) == 0:
             prefix = "/usr/local"
         
-        mkdirCmd = sudo + "mkdir -p " + prefix + "/include/nlohmann/"
-        InstallCmd = sudo + "cp -rf ./include/nlohmann " + prefix + "/include" 
+        mkdirCmd = (sudo + "mkdir -p " + prefix + "/include/nlohmann/").split()
+        InstallCmd = (sudo + "cp -rf ./include/nlohmann " + prefix + "/include").split()
 
         print("\n=========== getJson.py =============")
         print(mkdirCmd)
         print(InstallCmd)        
         print("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n")
 
-        os.system(mkdirCmd)
-        os.system(InstallCmd)
+        subprocess.run(mkdirCmd, check=True)
+        subprocess.run(InstallCmd, check=True)
 
 
 

--- a/thirdparty/getLibOTe.py
+++ b/thirdparty/getLibOTe.py
@@ -1,6 +1,7 @@
 import os 
 import sys 
 import platform
+import subprocess
 
 
 def getLibOTe(install, prefix, par,libOTe, boost, relic):
@@ -8,11 +9,11 @@ def getLibOTe(install, prefix, par,libOTe, boost, relic):
     cwd = os.getcwd()
     
     if os.path.isdir("libOTe") == False:
-        os.system("git clone --recursive https://github.com/osu-crypto/libOTe.git")
+        subprocess.run("git clone --recursive https://github.com/osu-crypto/libOTe.git".split(), check=True)
 
     os.chdir(cwd + "/libOTe")
-    os.system("git checkout cf537295c47a3924c13030a9b796cee9d6ebeace ")
-    os.system("git submodule update ")
+    subprocess.run("git checkout cf537295c47a3924c13030a9b796cee9d6ebeace".split(), check=True)
+    subprocess.run("git submodule update".split(), check=True)
 
     osStr = (platform.system())
     
@@ -46,9 +47,9 @@ def getLibOTe(install, prefix, par,libOTe, boost, relic):
         cmakePrefix = "-DCMAKE_PREFIX_PATH=" + prefix
 
     cmd =  "python3 build.py " + sudo + " --par=" + str(par) + " " + installCmd + " " + debug
-    boostCmd = cmd + " --setup --boost "
-    relicCmd = cmd + " --setup --relic "
-    libOTeCmd = cmd + " -DENABLE_CIRCUITS=ON " + cmakePrefix;
+    boostCmd = (cmd + " --setup --boost ").split()
+    relicCmd = (cmd + " --setup --relic ").split()
+    libOTeCmd = (cmd + " -DENABLE_CIRCUITS=ON " + cmakePrefix).split()
     
     
     print("\n\n=========== getLibOTe.py ================")
@@ -61,11 +62,11 @@ def getLibOTe(install, prefix, par,libOTe, boost, relic):
     print("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n\n")
 
     if boost:
-        os.system(boostCmd)
+        subprocess.run(boostCmd, check=True)
     if relic:
-        os.system(relicCmd)
+        subprocess.run(relicCmd, check=True)
     if libOTe:
-        os.system(libOTeCmd)
+        subprocess.run(libOTeCmd, check=True)
 
     os.chdir(cwd)
     


### PR DESCRIPTION
This way, the script immediately exits when the execution of a command fails. In my case, I forgot to install cmake, however, the python script still exited with code 0, which caused me considerable headache.
This PR fixes this.